### PR TITLE
Add sphinx to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ setuptools.setup(
         'networkx',
         'requests',
         'python-igraph',
+        'sphinx',
     ],
     classifiers=[
         'Intended Audience :: Science/Research',


### PR DESCRIPTION
This will fix the following `ModuleNotFoundError`

```
import py4cytoscape as p4c
```

```
ModuleNotFoundError                       Traceback (most recent call last)
<ipython-input-2-c772b26fd5a4> in <module>
----> 1 import py4cytoscape as p4c

~\miniforge3\lib\site-packages\py4cytoscape\__init__.py in <module>
     20 """
     21 
---> 22 from .networks import *
     23 from .session import *
     24 from .layouts import *

~\miniforge3\lib\site-packages\py4cytoscape\networks.py in <module>
     50 from . import network_selection
     51 from . import layouts
---> 52 from . import session
     53 from . import sandbox
     54 

~\miniforge3\lib\site-packages\py4cytoscape\session.py in <module>
     24 # Internal module imports
     25 from . import commands
---> 26 from . import sandbox
     27 
     28 # Internal module convenience imports

~\miniforge3\lib\site-packages\py4cytoscape\sandbox.py in <module>
     24         `Sandboxing <https://py4cytoscape.readthedocs.io/en/latest/concepts.html#sandboxing>`_ in the Concepts section in the py4cytoscape User Manual.
     25 """
---> 26 from sphinx.addnodes import desc
     27 
     28 """Note that there is more detailed commentary and lower level functions in py4cytsocape_sandbox.py."""

ModuleNotFoundError: No module named 'sphinx'
```