### PR TITLE
Fix Key Type Conflict in `item_name_to_suid_list` Dictionary

### DIFF
--- a/py4cytoscape/py4cytoscape_utils.py
+++ b/py4cytoscape/py4cytoscape_utils.py
@@ -962,9 +962,13 @@ def _item_to_suid(item_names, table_name, network=None, base_url=DEFAULT_BASE_UR
     # Map all names to SUIDs for O(1) lookup, allowing multiple SUIDs per name
     item_name_to_suid_list = {}
     for suid, name in zip(df.index, df['name']):
+        try:
+            name = int(name)  # Attempt to convert the name to an integer.
+        except ValueError:
+            pass  # If conversion fails, keep the name as a string.
         if name not in item_name_to_suid_list:
-            item_name_to_suid_list[name] = []
-        item_name_to_suid_list[name].append(suid)
+            item_name_to_suid_list[name] = []  # Initialize the key with an empty list if it doesn't exist.
+        item_name_to_suid_list[name].append(suid)  # Add the suid to the list associated with the name.
 
     # Convert item names to SUIDs
     suid_list = []


### PR DESCRIPTION
Fixing #142 

#### Changes
The `item_to_suid` function has been updated to handle both integer and string keys seamlessly in the `item_name_to_suid_list` dictionary. The key changes include:

- Each key in the `item_name_to_suid_list` dictionary is now wrapped in a `try-except` block to attempt conversion to an integer. If the conversion fails, the key remains as a string.
- This approach ensures that keys, whether integers or strings, are correctly managed within the dictionary.

#### Impact on `normalize_list` Function
- The `normalize_list` function, which also attempts to convert each `item_name` to an integer, will now work harmoniously with this updated logic.
- This change eliminates conflicts during item lookups from the `item_name_to_suid_list` dictionary, enhancing the robustness of the lookup process.