### PR TITLE
Update docstrings

### DIFF
--- a/py4cytoscape/annotations.py
+++ b/py4cytoscape/annotations.py
@@ -137,7 +137,7 @@ def add_annotation_bounded_text(text=None, x_pos=None, y_pos=None, font_size=Non
         border_color (str): hexadecimal color; default is #000000 (black)
         border_opacity (int): Integer between 0 and 100; default is 100
         height (int): Height of bounding shape; default is based on text height
-        width (int) Width of bounding shape; default is based on text length
+        width (int): Width of bounding shape; default is based on text length
         name (str): Name of annotation object; default is "Text"
         canvas (str): Canvas to display annotation, i.e., foreground (default) or background
         z_order (int): Arrangement order specified by number (larger values are in front of smaller values); default is 0
@@ -221,7 +221,7 @@ def add_annotation_image(url=None, x_pos=None, y_pos=None, angle=None, opacity=N
         border_color (str): hexadecimal color; default is #000000 (black)
         border_opacity (int): Integer between 0 and 100; default is 100
         height (int): Height of bounding shape; default is based on text height
-        width (int) Width of bounding shape; default is based on text length
+        width (int): Width of bounding shape; default is based on text length
         name (str): Name of annotation object; default is "Text"
         canvas (str): Canvas to display annotation, i.e., foreground (default) or background
         z_order (int): Arrangement order specified by number (larger values are in front of smaller values); default is 0
@@ -311,7 +311,7 @@ def add_annotation_shape(type=None, custom_shape=None, x_pos=None, y_pos=None, a
         border_color (str): hexadecimal color; default is #000000 (black)
         border_opacity (int): Integer between 0 and 100; default is 100
         height (int): Height of bounding shape; default is based on text height
-        width (int) Width of bounding shape; default is based on text length
+        width (int): Width of bounding shape; default is based on text length
         name (str): Name of annotation object; default is "Text"
         canvas (str): Canvas to display annotation, i.e., foreground (default) or background
         z_order (int): Arrangement order specified by number (larger values are in front of smaller values); default is 0
@@ -612,7 +612,7 @@ def update_annotation_bounded_text(text=None, annotation_name=None, x_pos=None, 
         border_color (str): hexadecimal color; default is #000000 (black)
         border_opacity (int): Integer between 0 and 100; default is 100
         height (int): Height of bounding shape; default is based on text height
-        width (int) Width of bounding shape; default is based on text length
+        width (int): Width of bounding shape; default is based on text length
         name (str): Name of annotation object; default is "Text"
         canvas (str): Canvas to display annotation, i.e., foreground (default) or background
         z_order (int): Arrangement order specified by number (larger values are in front of smaller values); default is 0
@@ -702,7 +702,7 @@ def update_annotation_shape(type=None, custom_shape=None, annotation_name=None, 
         border_color (str): hexadecimal color; default is #000000 (black)
         border_opacity (int): Integer between 0 and 100; default is 100
         height (int): Height of bounding shape; default is based on text height
-        width (int) Width of bounding shape; default is based on text length
+        width (int): Width of bounding shape; default is based on text length
         name (str): Name of annotation object; default is "Text"
         canvas (str): Canvas to display annotation, i.e., foreground (default) or background
         z_order (int): Arrangement order specified by number (larger values are in front of smaller values); default is 0
@@ -783,7 +783,7 @@ def update_annotation_image(url=None, annotation_name=None, x_pos=None, y_pos=No
         border_color (str): hexadecimal color; default is #000000 (black)
         border_opacity (int): Integer between 0 and 100; default is 100
         height (int): Height of bounding shape; default is based on text height
-        width (int) Width of bounding shape; default is based on text length
+        width (int): Width of bounding shape; default is based on text length
         name (str): Name of annotation object; default is "Text"
         canvas (str): Canvas to display annotation, i.e., foreground (default) or background
         z_order (int): Arrangement order specified by number (larger values are in front of smaller values); default is 0

--- a/py4cytoscape/commands.py
+++ b/py4cytoscape/commands.py
@@ -375,7 +375,7 @@ def commands_post(cmd, base_url=DEFAULT_BASE_URL):
     query URL, executes a POST request, and parses the result content into a dict object.
 
     Args:
-        cmd_string (str): command
+        cmd (str): Command to be executed in Cytoscape.
         base_url (str): Ignore unless you need to specify a custom domain,
             port or version to connect to the CyREST API. Default is http://127.0.0.1:1234
             and the latest version of the CyREST API supported by this version of py4cytoscape.
@@ -556,6 +556,8 @@ def command_run_file(file, args=None, base_url=DEFAULT_BASE_URL):
     Cytoscape commands, one per line. Arguments to the script are provided by the args argument
 
     Args:
+        file (str): Path to the file containing Cytoscape commands, one per line.
+        args (list or None): Provide arguments to the script. Default is None.
         base_url (str): Ignore unless you need to specify a custom domain,
             port or version to connect to the CyREST API. Default is http://127.0.0.1:1234
             and the latest version of the CyREST API supported by this version of py4cytoscape.

--- a/py4cytoscape/cy_ndex.py
+++ b/py4cytoscape/cy_ndex.py
@@ -183,7 +183,6 @@ def get_network_ndex_id(network=None, base_url=DEFAULT_BASE_URL):
     Args:
         network (SUID or str or None): Name or SUID of a network. Default is the
             "current" network active in Cytoscape.
-        metadata (dict): A list of structured information describing the network
         base_url (str): Ignore unless you need to specify a custom domain,
             port or version to connect to the CyREST API. Default is http://localhost:1234
             and the latest version of the CyREST API supported by this version of py4cytoscape.

--- a/py4cytoscape/filters.py
+++ b/py4cytoscape/filters.py
@@ -95,7 +95,7 @@ def create_column_filter(filter_name, column, criterion, predicate, caseSensitiv
     Args:
         filter_name (str): Name for new filter.
         column (str): Table column to base filter upon.
-        criterion (list, bool, str, int or float): For boolean columns: True or False. For string columns: a
+        criterion (list or bool or str or int or float): For boolean columns: True or False. For string columns: a
             string value, e.g., "hello". If the predicate is REGEX then this can be a regular expression as
             accepted by the Java Pattern class (https://docs.oracle.com/javase/7/docs/api/java/util/regex/Pattern.html).
             For numeric columns: If the predicate is BETWEEN or IS_NOT_BETWEEN then this is a two-element list of
@@ -199,7 +199,7 @@ def create_degree_filter(filter_name, criterion, predicate='BETWEEN', edge_type=
         filter_name (str): Name for new filter.
         criterion (list): A two-element vector of numbers, example: [1,5].
         predicate (str):  BETWEEN (default) or IS_NOT_BETWEEN
-        edgeType (str): Type of edges to consider in degree count: ANY (default), UNDIRECTED, INCOMING, OUTGOING, DIRECTED
+        edge_type (str): Type of edges to consider in degree count: ANY (default), UNDIRECTED, INCOMING, OUTGOING, DIRECTED
         hide (bool): Whether to hide filtered out nodes and edges. Default is FALSE.
             Ignored if all nodes or edges are filtered out. This is an alternative to filtering for node and edge selection.
         network (SUID or str or None): Name or SUID of the network. Default is the "current" network active in Cytoscape.

--- a/py4cytoscape/groups.py
+++ b/py4cytoscape/groups.py
@@ -266,7 +266,7 @@ def get_group_info(group, network=None, base_url=DEFAULT_BASE_URL):
     """Retrieve information about a group by name or identifier.
 
     Args:
-        group_name (str or SUID): Group name or SUID.
+        group (str or SUID): Group name or SUID.
         network (SUID or str or None): Name or SUID of a network. Default is the
             "current" network active in Cytoscape.
         base_url (str): Ignore unless you need to specify a custom domain,
@@ -406,7 +406,7 @@ def delete_group(groups=None, groups_by_col='SUID', network=None, base_url=DEFAU
     """Delete one or more groups, while leaving member nodes intact.
 
     Args:
-        groups (list or str or None) List of group SUIDs, names, other column values or keywords: all, selected,
+        groups (list or str or None): List of group SUIDs, names, other column values or keywords: all, selected,
             unselected. Default is the currently selected group.
         groups_by_col (str): name of node table column corresponding to provided groups list. Default is 'SUID'.
         network (SUID or str or None): Name or SUID of a network. Default is the

--- a/py4cytoscape/network_views.py
+++ b/py4cytoscape/network_views.py
@@ -277,7 +277,7 @@ def export_image(filename=None, type='PNG', resolution=None, units=None, height=
         type (str): Type of image to export, e.g., PNG (default), JPEG, PDF, SVG, PS (PostScript).
         resolution (int): The resolution of the exported image, in DPI. Valid only for bitmap formats, when the selected
             width and height 'units' is inches. The possible values are: 72 (default), 100, 150, 300, 600. [DEPRECATED as of Cytoscape v3.10]
-        units (str) The units for the 'width' and 'height' values. Valid only for bitmap formats, such as PNG and JPEG.
+        units (str): The units for the 'width' and 'height' values. Valid only for bitmap formats, such as PNG and JPEG.
             The possible values are: pixels (default), inches. [DEPRECATED as of Cytoscape v3.10]
         height (float): The height of the exported image. Valid only for bitmap formats, such as PNG and JPEG. [DEPRECATED as of Cytoscape v3.10]
         width (float): The width of the exported image. Valid only for bitmap formats, such as PNG and JPEG. [DEPRECATED as of Cytoscape v3.10]
@@ -448,8 +448,6 @@ def toggle_graphics_details(base_url=DEFAULT_BASE_URL):
     See :meth:`cytoscape_memory_status`.
 
     Args:
-        network (str or SUID or None): Name or SUID of the network or view. Default is the "current" network active in Cytoscape.
-            If a network view SUID is provided, then it is validated and returned.
         base_url (str): Ignore unless you need to specify a custom domain,
             port or version to connect to the CyREST API. Default is http://127.0.0.1:1234
             and the latest version of the CyREST API supported by this version of py4cytoscape.

--- a/py4cytoscape/networks.py
+++ b/py4cytoscape/networks.py
@@ -215,7 +215,7 @@ def get_network_suid(title=None, base_url=DEFAULT_BASE_URL):
     """Get the SUID of a network.
 
     Args:
-        suid (SUID or str or None): Name of the network; default is "current" network. If an SUID is
+        title (SUID or str or None): Name of the network; default is "current" network. If an SUID is
             provided, then it is validated and returned.
         base_url (str): Ignore unless you need to specify a custom domain,
             port or version to connect to the CyREST API. Default is http://127.0.0.1:1234
@@ -608,7 +608,7 @@ def add_cy_edges(source_target_list, edge_type='interacts with', directed=False,
 
     Args:
         source_target_list (list or list of lists): Source and target node pairs
-        edgeType (str): The type of interaction. Default is 'interacts with'.
+        edge_type (str): The type of interaction. Default is 'interacts with'.
         directed (bool): Indicates whether interactions are directed. Default is ``FALSE``.
         network (SUID or str or None): Name or SUID of a network or view. Default is the
             "current" network active in Cytoscape.
@@ -991,7 +991,7 @@ def create_network_from_networkx(netx, title='From networkx', collection='My Net
     """Create a Cytoscape network from a NetworkX graph.
 
     Args:
-        netx (Graph, DiGraph, MultiGraph or MultiDiGraph): networkx object
+        netx (Graph or DiGraph or MultiGraph or MultiDiGraph): networkx object
         title (str): network name
         collection (str): network collection name
         base_url (str): Ignore unless you need to specify a custom domain,

--- a/py4cytoscape/notebook.py
+++ b/py4cytoscape/notebook.py
@@ -45,7 +45,7 @@ def notebook_export_show_image(filename='image', type='PNG', resolution=None, un
         type (str): Type of image to export, e.g., PNG (default), JPEG, PDF, SVG, PS (PostScript).
         resolution (int): The resolution of the exported image, in DPI. Valid only for bitmap formats, when the selected
             width and height 'units' is inches. The possible values are: 72 (default), 100, 150, 300, 600.
-        units (str) The units for the 'width' and 'height' values. Valid only for bitmap formats, such as PNG and JPEG.
+        units (str): The units for the 'width' and 'height' values. Valid only for bitmap formats, such as PNG and JPEG.
             The possible values are: pixels (default), inches.
         height (float): The height of the exported image. Valid only for bitmap formats, such as PNG and JPEG.
         width (float): The width of the exported image. Valid only for bitmap formats, such as PNG and JPEG.

--- a/py4cytoscape/sandbox.py
+++ b/py4cytoscape/sandbox.py
@@ -366,6 +366,7 @@ def sandbox_get_from(source_file, dest_file=None, overwrite=True, sandbox_name =
     Args:
         source_file (str): Name of file to read (as absolute path or sandbox-relative path)
         dest_file (str): Name of file in the Python workflow's file system ... if None, use file name in source_file
+        overwrite (bool): False causes error if dest_file already exists; True replaces it if it exists
         sandbox_name (str): Name of sandbox containing file. None means "the current sandbox".
         base_url (str): Ignore unless you need to specify a custom domain,
             port or version to connect to the CyREST API. Default is http://localhost:1234

--- a/py4cytoscape/style_auto_mappings.py
+++ b/py4cytoscape/style_auto_mappings.py
@@ -652,6 +652,12 @@ def palette_color_brewer_d_RdYlGn(reverse=False):
 def scheme_d_shapes(base_url=DEFAULT_BASE_URL):
     """Generate list of node shapes of a given size
 
+    Args:
+        base_url (str): Ignore unless you need to specify a custom domain, port or 
+        version to connect to the CyREST API. Default is http://localhost:1234 
+        and the latest version of the CyREST API supported by this version of 
+        py4cytoscape.
+
     Returns:
         lambda: generates a list of shapes
 
@@ -667,6 +673,12 @@ def scheme_d_shapes(base_url=DEFAULT_BASE_URL):
 def scheme_d_line_styles(base_url=DEFAULT_BASE_URL):
     """Generate list of line styles of a given size
 
+    Args:
+        base_url (str): Ignore unless you need to specify a custom domain, port or 
+        version to connect to the CyREST API. Default is http://localhost:1234 
+        and the latest version of the CyREST API supported by this version of 
+        py4cytoscape.
+
     Returns:
         lambda: generates a list of line styles
 
@@ -681,6 +693,12 @@ def scheme_d_line_styles(base_url=DEFAULT_BASE_URL):
 @_scheme('discrete')
 def scheme_d_arrow_shapes(base_url=DEFAULT_BASE_URL):
     """Generate list of arrow shapes of a given size
+
+    Args:
+        base_url (str): Ignore unless you need to specify a custom domain, port or 
+        version to connect to the CyREST API. Default is http://localhost:1234 
+        and the latest version of the CyREST API supported by this version of 
+        py4cytoscape.
 
     Returns:
         lambda: generates a list of arrow shapes
@@ -942,6 +960,7 @@ def gen_edge_opacity_map(table_column,
     Args:
         table_column (str): Name of Cytoscape edge table column to map values from
         number_scheme (dict or func): Descriptor for functions that return an opacity list of a given length
+        mapping_type (str): continuous or discrete (c, d) mapping; default is continuous
         default_number (int): Opacity value to set as default for all unmapped values
         style_name (str): name for style
         network (SUID or str or None): Name or SUID of a network or view. Default is the
@@ -1000,6 +1019,7 @@ def gen_node_width_map(table_column,
     Args:
         table_column (str): Name of Cytoscape node table column to map values from
         number_scheme (dict or func): Descriptor for functions that return a width list of a given length
+        mapping_type (str): continuous or discrete (c, d); default is continuous
         default_number (int): width value to set as default for all unmapped values
         style_name (str): name for style
         network (SUID or str or None): Name or SUID of a network or view. Default is the
@@ -1227,6 +1247,7 @@ def gen_edge_size_map(table_column,
     Args:
         table_column (str): Name of Cytoscape node table column to map values from
         number_scheme (dict or func): Descriptor for functions that return a size list of a given length
+        mapping_type (str): continuous or discrete (c, d); default is continuous
         default_number (int): size value to set as default for all unmapped values
         style_name (str): name for style
         network (SUID or str or None): Name or SUID of a network or view. Default is the

--- a/py4cytoscape/style_auto_mappings.py
+++ b/py4cytoscape/style_auto_mappings.py
@@ -649,7 +649,7 @@ def palette_color_brewer_d_RdYlGn(reverse=False):
 # ------------------------------------------------------------------------------
 
 @_scheme('discrete')
-def scheme_d_shapes(=DEFAULT_BASE_URL):
+def scheme_d_shapes(base_url=DEFAULT_BASE_URL):
     """Generate list of node shapes of a given size
 
     Args:

--- a/py4cytoscape/style_auto_mappings.py
+++ b/py4cytoscape/style_auto_mappings.py
@@ -649,14 +649,13 @@ def palette_color_brewer_d_RdYlGn(reverse=False):
 # ------------------------------------------------------------------------------
 
 @_scheme('discrete')
-def scheme_d_shapes(base_url=DEFAULT_BASE_URL):
+def scheme_d_shapes(=DEFAULT_BASE_URL):
     """Generate list of node shapes of a given size
 
     Args:
-        base_url (str): Ignore unless you need to specify a custom domain, port or 
-        version to connect to the CyREST API. Default is http://localhost:1234 
-        and the latest version of the CyREST API supported by this version of 
-        py4cytoscape.
+        base_url (str): Ignore unless you need to specify a custom domain,
+            port or version to connect to the CyREST API. Default is http://localhost:1234
+            and the latest version of the CyREST API supported by this version of py4cytoscape.
 
     Returns:
         lambda: generates a list of shapes
@@ -674,10 +673,9 @@ def scheme_d_line_styles(base_url=DEFAULT_BASE_URL):
     """Generate list of line styles of a given size
 
     Args:
-        base_url (str): Ignore unless you need to specify a custom domain, port or 
-        version to connect to the CyREST API. Default is http://localhost:1234 
-        and the latest version of the CyREST API supported by this version of 
-        py4cytoscape.
+        base_url (str): Ignore unless you need to specify a custom domain,
+            port or version to connect to the CyREST API. Default is http://localhost:1234
+            and the latest version of the CyREST API supported by this version of py4cytoscape.
 
     Returns:
         lambda: generates a list of line styles
@@ -695,10 +693,9 @@ def scheme_d_arrow_shapes(base_url=DEFAULT_BASE_URL):
     """Generate list of arrow shapes of a given size
 
     Args:
-        base_url (str): Ignore unless you need to specify a custom domain, port or 
-        version to connect to the CyREST API. Default is http://localhost:1234 
-        and the latest version of the CyREST API supported by this version of 
-        py4cytoscape.
+        base_url (str): Ignore unless you need to specify a custom domain,
+            port or version to connect to the CyREST API. Default is http://localhost:1234
+            and the latest version of the CyREST API supported by this version of py4cytoscape.
 
     Returns:
         lambda: generates a list of arrow shapes

--- a/py4cytoscape/style_bypasses.py
+++ b/py4cytoscape/style_bypasses.py
@@ -181,7 +181,6 @@ def clear_node_property_bypass(node_names, visual_property, network=None, base_u
             comma-separated string of node names or SUIDs, or scalar node name
             or SUID. Node names should be found in the ``name`` column of the ``nodes table``.
         visual_property (str): Name of a visual property. See ``get_visual_property_names``.
-        bypass (bool): Whether to set permanent bypass value. Default is True
         network (SUID or str or None): Name or SUID of a network. Default is the
             "current" network active in Cytoscape.
         base_url (str): Ignore unless you need to specify a custom domain,
@@ -371,7 +370,6 @@ def clear_edge_property_bypass(edge_names, visual_property, network=None, base_u
             comma-separated string of edge names or SUIDs, or scalar edge name
             or SUID. Edge names should be found in the ``name`` column of the ``edges table``.
         visual_property (str): Name of a visual property. See ``get_visual_property_names``.
-        bypass (bool): Whether to set permanent bypass value. Default is True
         network (SUID or str or None): Name or SUID of a network. Default is the
             "current" network active in Cytoscape.
         base_url (str): Ignore unless you need to specify a custom domain,
@@ -485,7 +483,6 @@ def clear_network_property_bypass(visual_property, network=None, base_url=DEFAUL
 
     Args:
         visual_property (str): Name of a visual property. See ``get_visual_property_names``.
-        bypass (bool): Whether to set permanent bypass value. Default is True
         network (SUID or str or None): Name or SUID of a network. Default is the
             "current" network active in Cytoscape.
         base_url (str): Ignore unless you need to specify a custom domain,
@@ -693,8 +690,8 @@ def set_node_position_bypass(node_names, new_x_locations=None, new_y_locations=N
         node_names (str or list or int): List of nodes as ``list`` of node names or SUIDs,
             comma-separated string of node names or SUIDs, or scalar node name
             or SUID. Node names should be found in the ``name`` column of the ``nodes table``.
-        new_x_locations (list, int or float): List of x position values, or single value, default is current x position
-        new_y_locations (list, int or float): List of y position values, or single value, default is current y position
+        new_x_locations (list or int or float): List of x position values, or single value, default is current x position
+        new_y_locations (list or int or float): List of y position values, or single value, default is current y position
         network (SUID or str or None): Name or SUID of a network. Default is the
             "current" network active in Cytoscape.
         base_url (str): Ignore unless you need to specify a custom domain,

--- a/py4cytoscape/style_defaults.py
+++ b/py4cytoscape/style_defaults.py
@@ -318,7 +318,7 @@ def set_node_custom_bar_chart(columns, type='GROUPED', colors=None, range=None, 
         orientation (str): HORIZONTAL or VERTICAL (default).
         col_axis (bool): Show axis with column labels. Default is False.
         range_axis (bool): Show axis with range of values. Default is False.
-        zero_line (book): Show a line at zero. Default is False.
+        zero_line (bool): Show a line at zero. Default is False.
         axis_width (float): Width of axis lines, if shown. Default is 0.25.
         axis_color (str): Color of axis lines, if shown. Default is black ('#000000').
         axis_font_size(int): Font size of axis labels, if shown. Default is 1.
@@ -399,9 +399,8 @@ def set_node_custom_box_chart(columns, colors=None, range=None, orientation='VER
             set of colors from an appropriate Brewer cy_palette.
         range (list): Min and max values of chart. Default is to use min and max from specified data columns.
         orientation (str): HORIZONTAL or VERTICAL (default).
-        col_axis (bool): Show axis with column labels. Default is False.
         range_axis (bool): Show axis with range of values. Default is False.
-        zero_line (book): Show a line at zero. Default is False.
+        zero_line (bool): Show a line at zero. Default is False.
         axis_width (float): Width of axis lines, if shown. Default is 0.25.
         axis_color (str): Color of axis lines, if shown. Default is black ('#000000').
         axis_font_size(int): Font size of axis labels, if shown. Default is 1.
@@ -472,7 +471,7 @@ def set_node_custom_heat_map_chart(columns, colors=None, range=None, orientation
         range (list): Min and max values of chart. Default is to use min and max from specified data columns.
         orientation (str): HORIZONTAL (default) or VERTICAL.
         range_axis (bool): Show axis with range of values. Default is False.
-        zero_line (book): Show a line at zero. Default is False.
+        zero_line (bool): Show a line at zero. Default is False.
         axis_width (float): Width of axis lines, if shown. Default is 0.25.
         axis_color (str): Color of axis lines, if shown. Default is black ('#000000').
         axis_font_size(int): Font size of axis labels, if shown. Default is 1.
@@ -545,7 +544,7 @@ def set_node_custom_line_chart(columns, colors=None, range=None, line_width=1.0,
         range (list): Min and max values of chart. Default is to use min and max from specified data columns.
         line_width (float): Width of chart line. Default is 1.0.
         range_axis (bool): Show axis with range of values. Default is False.
-        zero_line (book): Show a line at zero. Default is False.
+        zero_line (bool): Show a line at zero. Default is False.
         axis_width (float): Width of axis lines, if shown. Default is 0.25.
         axis_color (str): Color of axis lines, if shown. Default is black ('#000000').
         axis_font_size(int): Font size of axis labels, if shown. Default is 1.

--- a/py4cytoscape/style_values.py
+++ b/py4cytoscape/style_values.py
@@ -46,7 +46,7 @@ def get_node_property(node_names=None, visual_property=None, network=None, base_
     """Get values for any node property of the specified nodes.
 
     Args:
-        nodes_names (str or list or int or None): List of nodes or None. If node list:
+        node_names (str or list or int or None): List of nodes or None. If node list:
             ``list`` of node names or SUIDs, comma-separated string of node names or SUIDs, or scalar node name
             or SUID. Node names should be found in the ``name`` column of the ``node table``. If list is None,
             default is all nodes.
@@ -221,7 +221,7 @@ def get_node_color(node_names=None, network=None, base_url=DEFAULT_BASE_URL):
     """Retrieve the actual fill color of specified nodes.
 
     Args:
-        nodes_names (str or list or int or None): List of nodes or None. If node list:
+        node_names (str or list or int or None): List of nodes or None. If node list:
             ``list`` of node names or SUIDs, comma-separated string of node names or SUIDs, or scalar node name
             or SUID. Node names should be found in the ``name`` column of the ``node table``. If list is None,
             default is all nodes.
@@ -267,7 +267,7 @@ def get_node_size(node_names=None, network=None, base_url=DEFAULT_BASE_URL):
     """Retrieve the actual size of specified nodes.
 
     Args:
-        nodes_names (str or list or int or None): List of nodes or None. If node list:
+        node_names (str or list or int or None): List of nodes or None. If node list:
             ``list`` of node names or SUIDs, comma-separated string of node names or SUIDs, or scalar node name
             or SUID. Node names should be found in the ``name`` column of the ``node table``. If list is None,
             default is all nodes.
@@ -313,7 +313,7 @@ def get_node_width(node_names=None, network=None, base_url=DEFAULT_BASE_URL):
     """Retrieve the actual width of specified nodes.
 
     Args:
-        nodes_names (str or list or int or None): List of nodes or None. If node list:
+        node_names (str or list or int or None): List of nodes or None. If node list:
             ``list`` of node names or SUIDs, comma-separated string of node names or SUIDs, or scalar node name
             or SUID. Node names should be found in the ``name`` column of the ``node table``. If list is None,
             default is all nodes.
@@ -359,7 +359,7 @@ def get_node_height(node_names=None, network=None, base_url=DEFAULT_BASE_URL):
     """Retrieve the actual height of specified nodes.
 
     Args:
-        nodes_names (str or list or int or None): List of nodes or None. If node list:
+        node_names (str or list or int or None): List of nodes or None. If node list:
             ``list`` of node names or SUIDs, comma-separated string of node names or SUIDs, or scalar node name
             or SUID. Node names should be found in the ``name`` column of the ``node table``. If list is None,
             default is all nodes.
@@ -405,7 +405,7 @@ def get_node_position(node_names=None, network=None, base_url=DEFAULT_BASE_URL):
     """Retrieve the actual x,y position of specified nodes.
 
     Args:
-        nodes_names (str or list or int or None): List of nodes or None. If node list:
+        node_names (str or list or int or None): List of nodes or None. If node list:
             ``list`` of node names or SUIDs, comma-separated string of node names or SUIDs, or scalar node name
             or SUID. Node names should be found in the ``name`` column of the ``node table``. If list is None,
             default is all nodes.

--- a/py4cytoscape/styles.py
+++ b/py4cytoscape/styles.py
@@ -229,7 +229,7 @@ def export_visual_styles(filename=None, type='XML', styles=None, base_url=DEFAUL
             Default is "styles.xml"
         type (str): Type of data file to export, e.g., XML, JSON (case sensitive).
             Default is XML. Note: Only XML can be read by ``import_visual_styles()``.
-        styles (str) The styles to be exported, listed as a comma-separated string. If no styles are
+        styles (str): The styles to be exported, listed as a comma-separated string. If no styles are
             specified, only the current one is exported.
         base_url (str): Ignore unless you need to specify a custom domain,
             port or version to connect to the CyREST API. Default is http://127.0.0.1:1234
@@ -339,6 +339,7 @@ def set_visual_style(style_name, network=None, base_url=DEFAULT_BASE_URL):
 
     Args:
         style_name (str): Name of a visual style
+        network (SUID or str or None): Name or SUID of the network. Default is the "current" network active in Cytoscape.
         base_url (str): Ignore unless you need to specify a custom domain,
             port or version to connect to the CyREST API. Default is http://127.0.0.1:1234
             and the latest version of the CyREST API supported by this version of py4cytoscape.

--- a/py4cytoscape/tables.py
+++ b/py4cytoscape/tables.py
@@ -525,8 +525,8 @@ def map_table_column(column, species, map_from, map_to, force_single=True, table
         column (str): Name of column containing identifiers of type specified by ``map.from``
         species (str): Common name for species associated with identifiers, e.g., Human. See details.
         map_from (str): Type of identifier found in specified ``column``. See details.
-        map.to (str): Type of identifier to populate in new column. See details.
-        force.single (bool): Whether to return only first result in cases of one-to-many mappings; otherwise
+        map_to (str): Type of identifier to populate in new column. See details.
+        force_single (bool): Whether to return only first result in cases of one-to-many mappings; otherwise
             the new column will hold lists of identifiers. Default is TRUE.
         table (str): name of Cytoscape table to load data into, e.g., node, edge or network; default is "node"
         namespace (str): Namespace of table. Default is "default".

--- a/py4cytoscape/tools.py
+++ b/py4cytoscape/tools.py
@@ -201,7 +201,7 @@ def cybrowser_send(id=None, script='', base_url=DEFAULT_BASE_URL):
 
     Args:
         id (str): The identifier for the new browser window
-        script (str) A string that represents a JavaScript variable, script, or call to be executed in the browser.
+        script (str): A string that represents a JavaScript variable, script, or call to be executed in the browser.
             Note that only string results are returned.
         base_url (str): Ignore unless you need to specify a custom domain,
             port or version to connect to the CyREST API. Default is http://127.0.0.1:1234
@@ -398,7 +398,7 @@ def merge_networks(sources=None,
         network_merge_map (list): A list of column merge records specifying how to merge network table data. Each record
             should be of the form: ["network1 column", "network2 column", "merged column", "type"], where column names
             are provided and type is String, Integer, Double or List.
-        in_network_merge (bool) If True (default), nodes and edges with matching attributes in the same network will be
+        in_network_merge (bool): If True (default), nodes and edges with matching attributes in the same network will be
             merged.
         base_url (str): Ignore unless you need to specify a custom domain,
             port or version to connect to the CyREST API. Default is http://127.0.0.1:1234

--- a/py4cytoscape/user_interface.py
+++ b/py4cytoscape/user_interface.py
@@ -133,8 +133,6 @@ def hide_all_panels(base_url=DEFAULT_BASE_URL):
     """Hide control, table, tool and results panels.
 
     Args:
-        panel_name (str): Name of the panel. Multiple ways of referencing panels is supported:
-           (WEST == control panel, control, c), (SOUTH == table panel, table, ta), (SOUTH_WEST == tool panel, tool, to), (EAST == results panel, results, r)
         base_url (str): Ignore unless you need to specify a custom domain,
             port or version to connect to the CyREST API. Default is http://127.0.0.1:1234
             and the latest version of the CyREST API supported by this version of py4cytoscape.


### PR DESCRIPTION
**Changes**

- Align parameter names in `Args:` with function signatures
- Enforce `name (type): description` (add missing `:`)
- Fix minor type tokens (e.g., `book`→`bool`)
- Add missing one-line descriptions
- Remove doc-only params: drop `Args:` entries not in the signature.