### PR TITLE
docs: add Appyter Enrichment Analysis Visualizer Docker startup + port mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,62 @@ For an explanation of log configuration and use, see the [LOGGING.rst](LOGGING.r
  
 
 
+# Running the Enrichment Analysis Visualizer Appyter (Docker)
+
+The [Enrichment Analysis Visualizer Appyter](https://appyters.maayanlab.cloud/) can be run locally as a Docker container to complement `py4cytoscape` analyses. It serves a Flask web app on container port `5000`.
+
+## Prerequisites
+
+- Docker is installed and the daemon is running (on macOS, start Docker Desktop: `open -a Docker`).
+
+## Start the container
+
+```bash
+docker run -d --name appyter-eav \
+  --device /dev/fuse --cap-add SYS_ADMIN --security-opt apparmor:unconfined \
+  -p 5001:5000 \
+  maayanlab/appyter-enrichment_analysis_visualizer:0.2.7-0.19.17 \
+  appyter flask-app
+```
+
+Notes:
+
+- **Start command is required.** The image's default command is `/bin/sh`, so it must be launched with `appyter flask-app` to start the web server. Running it without a command (or with only `-it`) drops you into a shell instead of serving the app.
+- **Image tag.** Use a tag that exists on Docker Hub — `0.2.7-0.19.17` is the latest at time of writing. Verify current tags with:
+  ```bash
+  curl -s "https://hub.docker.com/v2/repositories/maayanlab/appyter-enrichment_analysis_visualizer/tags?page_size=25&ordering=last_updated"
+  ```
+- **FUSE flags.** `--device /dev/fuse --cap-add SYS_ADMIN --security-opt apparmor:unconfined` are required by the Appyter runtime for filesystem mounting.
+- **Platform.** The image is `linux/amd64`; on Apple Silicon it runs under emulation (a harmless platform-mismatch warning is expected).
+
+## Port mapping
+
+The container listens on port `5000` internally (`APPYTER_PORT=5000`). Map it to a host port with `-p <host>:5000`.
+
+- On macOS, host port `5000` is often already taken by the **Control Center / AirPlay Receiver** service, causing `bind: address already in use`. The example above maps to host port **`5001`** to avoid this. Check what holds a port with:
+  ```bash
+  lsof -nP -iTCP:5000 -sTCP:LISTEN
+  ```
+- To use host port `5000` instead, free it first (System Settings → General → AirDrop & Handoff → turn off **AirPlay Receiver**), then run with `-p 5000:5000`.
+
+## Verify it is accessible
+
+```bash
+curl -s -o /dev/null -w "%{http_code}\n" http://localhost:5001/
+```
+
+A `200` response indicates the app is up (during startup you may briefly see `502`). Then open it in a browser:
+
+```
+http://localhost:5001
+```
+
+## Stop and remove
+
+```bash
+docker rm -f appyter-eav
+```
+
 ## License
 
 ``py4cytoscape`` is released under the MIT License (see [LICENSE.rst](LICENSE.rst) file):


### PR DESCRIPTION
## Summary
Adds a section to `README.md` documenting how to run the **Enrichment Analysis Visualizer Appyter** (`maayanlab/appyter-enrichment_analysis_visualizer`) locally as a Docker container to complement `py4cytoscape` analyses.

## What's included
- **Prerequisites** — Docker running (`open -a Docker` on macOS).
- **Start command** — full `docker run` invocation, including the required `appyter flask-app` command (the image's default `Cmd` is `/bin/sh`, so it must be provided) and the required FUSE flags (`--device /dev/fuse --cap-add SYS_ADMIN --security-opt apparmor:unconfined`).
- **Image tag guidance** — use a tag that exists on Docker Hub (`0.2.7-0.19.17` latest at time of writing) plus a command to list current tags.
- **Port mapping** — container serves on `5000`; documents the common macOS AirPlay Receiver conflict on host port `5000`, how to diagnose it (`lsof`), and mapping to `5001` (or freeing `5000`).
- **Verification** (`curl` health check) and **teardown**.

The documented procedure was validated end-to-end (`HTTP 200`, page title `Appyter`).

Co-Authored-By: Oz <oz-agent@warp.dev>