### PR TITLE
feat: add optional LM Studio LLM inference utility module

### DIFF
--- a/py4cytoscape/__init__.py
+++ b/py4cytoscape/__init__.py
@@ -51,6 +51,7 @@ from .py4cytoscape_tuning import set_catchup_filter_secs, set_catchup_network_se
 from ._version import __version__
 from .notebook import *
 from .annotations import *
+from .llm_inference import *
 
 # Note that we have tried to enforce documentation standards for modules and private functions per:
 # https://www.python.org/dev/peps/pep-0257/ and https://www.python.org/dev/peps/pep-0008/#comments

--- a/py4cytoscape/llm_inference.py
+++ b/py4cytoscape/llm_inference.py
@@ -1,0 +1,196 @@
+# -*- coding: utf-8 -*-
+
+"""Functions for running local LLM inference via the LM Studio Python SDK.
+
+These helpers provide a thin, optional wrapper around the ``lmstudio`` package
+so that py4cytoscape workflows can send prompts to a locally running LM Studio
+server (for example, to summarize a network, explain results, or draft
+annotations) without depending on any cloud service.
+
+The ``lmstudio`` package is an *optional* dependency. It is imported lazily so
+that py4cytoscape continues to work when the package is not installed; the LLM
+functions raise a helpful :class:`CyError` in that case. Install it with::
+
+    pip install lmstudio
+
+and ensure the LM Studio server is running (``lms server start``).
+"""
+
+"""Copyright 2020-2022 The Cytoscape Consortium
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated 
+documentation files (the "Software"), to deal in the Software without restriction, including without limitation the 
+rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit 
+persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the 
+Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO 
+THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE 
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, 
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+"""
+
+# External library imports
+import sys
+
+# Internal module convenience imports
+from .exceptions import CyError
+from .py4cytoscape_logger import cy_log
+
+# Default host:port for the LM Studio local server (distinct from Cytoscape's CyREST).
+DEFAULT_LLM_HOST = 'localhost:1234'
+
+
+def _import_lmstudio(caller):
+    """Import the optional ``lmstudio`` package or raise a helpful CyError."""
+    try:
+        import lmstudio  # noqa: F401  (imported for availability check)
+        return lmstudio
+    except ImportError:
+        raise CyError(
+            "The 'lmstudio' package is required for LLM inference but is not installed. "
+            "Install it with 'pip install lmstudio' and start the LM Studio server "
+            "with 'lms server start'.",
+            caller=caller)
+
+
+@cy_log
+def llm_server_reachable(host=DEFAULT_LLM_HOST):
+    """Check whether a local LM Studio server is reachable.
+
+    Args:
+        host (str): Host and port of the LM Studio server. Default is ``localhost:1234``.
+
+    Returns:
+        bool: True if the server responds, False otherwise.
+
+    Raises:
+        CyError: if the ``lmstudio`` package is not installed
+
+    Examples:
+        >>> llm_server_reachable()
+        True
+    """
+    lms = _import_lmstudio(sys._getframe().f_code.co_name)
+    try:
+        with lms.Client(api_host=host) as client:
+            client.list_downloaded_models()
+        return True
+    except Exception:
+        return False
+
+
+@cy_log
+def list_llm_models(host=DEFAULT_LLM_HOST):
+    """List the LLM models downloaded in the local LM Studio installation.
+
+    Args:
+        host (str): Host and port of the LM Studio server. Default is ``localhost:1234``.
+
+    Returns:
+        list: list of model key strings (e.g. ``['mistralai/mistral-7b-instruct-v0.3']``)
+
+    Raises:
+        CyError: if the ``lmstudio`` package is not installed or the server can't be reached
+
+    Examples:
+        >>> list_llm_models()
+        ['mistralai/mistral-7b-instruct-v0.3', 'text-embedding-nomic-embed-text-v1.5']
+    """
+    caller = sys._getframe().f_code.co_name
+    lms = _import_lmstudio(caller)
+    try:
+        with lms.Client(api_host=host) as client:
+            models = client.list_downloaded_models()
+    except Exception as e:
+        raise CyError(f"Could not reach LM Studio server at '{host}': {e}", caller=caller)
+
+    keys = []
+    for m in models:
+        keys.append(getattr(m, 'model_key', None) or getattr(m, 'path', None) or str(m))
+    return keys
+
+
+@cy_log
+def llm_infer(prompt, model_key=None, host=DEFAULT_LLM_HOST, config=None):
+    """Run a single-shot LLM completion against the local LM Studio server.
+
+    Args:
+        prompt (str): The text prompt to send to the model.
+        model_key (str): Key of the model to use (e.g. ``mistralai/mistral-7b-instruct-v0.3``).
+            If None, the currently loaded/default model is used.
+        host (str): Host and port of the LM Studio server. Default is ``localhost:1234``.
+        config (dict): Optional inference parameters passed through to the SDK,
+            e.g. ``{'temperature': 0.7, 'maxTokens': 256}``.
+
+    Returns:
+        str: The model's response text.
+
+    Raises:
+        CyError: if the ``lmstudio`` package is not installed, the server can't be
+            reached, or inference fails
+
+    Examples:
+        >>> llm_infer('Summarize what a protein-protein interaction network is.')
+        'A protein-protein interaction network represents ...'
+        >>> llm_infer('Say hello', model_key='mistralai/mistral-7b-instruct-v0.3', config={'temperature': 0.2})
+        'Hello! How can I help you today?'
+    """
+    caller = sys._getframe().f_code.co_name
+    if prompt is None or str(prompt).strip() == '':
+        raise CyError('prompt must be a non-empty string', caller=caller)
+    lms = _import_lmstudio(caller)
+    try:
+        with lms.Client(api_host=host) as client:
+            model = client.llm.model(model_key) if model_key else client.llm.model()
+            result = model.respond(prompt, config=config) if config else model.respond(prompt)
+            return str(result)
+    except CyError:
+        raise
+    except Exception as e:
+        raise CyError(f"LLM inference failed on host '{host}': {e}", caller=caller)
+
+
+@cy_log
+def llm_infer_stream(prompt, model_key=None, host=DEFAULT_LLM_HOST, config=None):
+    """Run a streaming LLM completion, yielding response text fragments.
+
+    This is useful for displaying tokens as they are produced. The LM Studio
+    connection remains open until the returned generator is exhausted.
+
+    Args:
+        prompt (str): The text prompt to send to the model.
+        model_key (str): Key of the model to use. If None, the currently loaded/default model is used.
+        host (str): Host and port of the LM Studio server. Default is ``localhost:1234``.
+        config (dict): Optional inference parameters passed through to the SDK,
+            e.g. ``{'temperature': 0.7, 'maxTokens': 256}``.
+
+    Returns:
+        Iterator[str]: an iterator of response text fragments
+
+    Raises:
+        CyError: if the ``lmstudio`` package is not installed, the server can't be
+            reached, or inference fails
+
+    Examples:
+        >>> for fragment in llm_infer_stream('List three graph layout algorithms.'):
+        ...     print(fragment, end='')
+    """
+    caller = sys._getframe().f_code.co_name
+    if prompt is None or str(prompt).strip() == '':
+        raise CyError('prompt must be a non-empty string', caller=caller)
+    lms = _import_lmstudio(caller)
+
+    def _generate():
+        try:
+            with lms.Client(api_host=host) as client:
+                model = client.llm.model(model_key) if model_key else client.llm.model()
+                stream = model.respond_stream(prompt, config=config) if config else model.respond_stream(prompt)
+                for fragment in stream:
+                    yield getattr(fragment, 'content', str(fragment))
+        except Exception as e:
+            raise CyError(f"LLM streaming inference failed on host '{host}': {e}", caller=caller)
+
+    return _generate()

--- a/py4cytoscape/llm_inference.py
+++ b/py4cytoscape/llm_inference.py
@@ -194,3 +194,174 @@ def llm_infer_stream(prompt, model_key=None, host=DEFAULT_LLM_HOST, config=None)
             raise CyError(f"LLM streaming inference failed on host '{host}': {e}", caller=caller)
 
     return _generate()
+
+
+@cy_log
+def llm_list_loaded_models(host=DEFAULT_LLM_HOST):
+    """List the LLM model identifiers currently loaded in memory in LM Studio.
+
+    Args:
+        host (str): Host and port of the LM Studio server. Default is ``localhost:1234``.
+
+    Returns:
+        list: list of identifier strings for each loaded model
+            (e.g. ``['mistralai/mistral-7b-instruct-v0.3']``)
+
+    Raises:
+        CyError: if the ``lmstudio`` package is not installed or the server can't be reached
+
+    Examples:
+        >>> llm_list_loaded_models()
+        ['mistralai/mistral-7b-instruct-v0.3']
+    """
+    caller = sys._getframe().f_code.co_name
+    lms = _import_lmstudio(caller)
+    try:
+        with lms.Client(api_host=host) as client:
+            handles = client.llm.list_loaded()
+    except Exception as e:
+        raise CyError(f"Could not reach LM Studio server at '{host}': {e}", caller=caller)
+    return [getattr(h, 'identifier', str(h)) for h in handles]
+
+
+@cy_log
+def llm_load_model(model_key, identifier=None, ttl=3600, config=None, host=DEFAULT_LLM_HOST):
+    """Load a model into memory in the local LM Studio server.
+
+    If the model is already loaded, no additional instance is created and the
+    existing model identifier is returned.
+
+    Args:
+        model_key (str): Model key to load (e.g. ``mistralai/mistral-7b-instruct-v0.3``).
+            Must correspond to a downloaded model.
+        identifier (str): Optional custom identifier for this instance. If None,
+            the server assigns one (usually the same as ``model_key``).
+        ttl (int): Time-to-live in seconds before the server auto-unloads the model
+            when idle. Default is 3600 (1 hour). Pass None to disable auto-unload.
+        config (dict): Optional model load parameters (e.g. context length, GPU layers).
+        host (str): Host and port of the LM Studio server. Default is ``localhost:1234``.
+
+    Returns:
+        str: The identifier of the loaded model instance.
+
+    Raises:
+        CyError: if the ``lmstudio`` package is not installed, ``model_key`` is empty,
+            the model is not downloaded, or the server can't be reached
+
+    Examples:
+        >>> llm_load_model('mistralai/mistral-7b-instruct-v0.3')
+        'mistralai/mistral-7b-instruct-v0.3'
+        >>> llm_load_model('mistralai/mistral-7b-instruct-v0.3', ttl=None)
+        'mistralai/mistral-7b-instruct-v0.3'
+    """
+    caller = sys._getframe().f_code.co_name
+    if not model_key or str(model_key).strip() == '':
+        raise CyError('model_key must be a non-empty string', caller=caller)
+    lms = _import_lmstudio(caller)
+    try:
+        with lms.Client(api_host=host) as client:
+            # Avoid loading a duplicate instance if already present
+            handles = client.llm.list_loaded()
+            for h in handles:
+                if getattr(h, 'identifier', None) == model_key:
+                    return model_key
+            kwargs = {'ttl': ttl}
+            if identifier is not None:
+                kwargs['instance_identifier'] = identifier
+            if config is not None:
+                kwargs['config'] = config
+            handle = client.llm.load_new_instance(model_key, **kwargs)
+            return getattr(handle, 'identifier', model_key)
+    except CyError:
+        raise
+    except Exception as e:
+        raise CyError(f"Failed to load model '{model_key}' on host '{host}': {e}", caller=caller)
+
+
+@cy_log
+def llm_unload_model(model_key, host=DEFAULT_LLM_HOST):
+    """Unload a model from memory in the local LM Studio server.
+
+    If the model is not currently loaded, the call is a no-op and returns False.
+
+    Args:
+        model_key (str): Identifier of the loaded model to unload.
+        host (str): Host and port of the LM Studio server. Default is ``localhost:1234``.
+
+    Returns:
+        bool: True if the model was unloaded, False if it was not loaded.
+
+    Raises:
+        CyError: if the ``lmstudio`` package is not installed, ``model_key`` is empty,
+            or the server can't be reached
+
+    Examples:
+        >>> llm_unload_model('mistralai/mistral-7b-instruct-v0.3')
+        True
+        >>> llm_unload_model('model/not-loaded')
+        False
+    """
+    caller = sys._getframe().f_code.co_name
+    if not model_key or str(model_key).strip() == '':
+        raise CyError('model_key must be a non-empty string', caller=caller)
+    lms = _import_lmstudio(caller)
+    try:
+        with lms.Client(api_host=host) as client:
+            handles = client.llm.list_loaded()
+            loaded_ids = [getattr(h, 'identifier', None) for h in handles]
+            if model_key not in loaded_ids:
+                return False
+            client.llm.unload(model_key)
+            return True
+    except CyError:
+        raise
+    except Exception as e:
+        raise CyError(f"Failed to unload model '{model_key}' on host '{host}': {e}", caller=caller)
+
+
+@cy_log
+def llm_ensure_model_loaded(model_key, ttl=3600, config=None, host=DEFAULT_LLM_HOST):
+    """Ensure a model is loaded, loading it first if necessary.
+
+    This is the recommended helper to call before running inference: it avoids
+    loading a redundant instance when the model is already in memory.
+
+    Args:
+        model_key (str): Model key to ensure is loaded.
+        ttl (int): Time-to-live in seconds passed to :func:`llm_load_model` when
+            the model needs to be loaded. Default is 3600 (1 hour).
+        config (dict): Optional load configuration passed to :func:`llm_load_model`.
+        host (str): Host and port of the LM Studio server. Default is ``localhost:1234``.
+
+    Returns:
+        bool: True if the model was already loaded, False if it had to be loaded now.
+
+    Raises:
+        CyError: if the ``lmstudio`` package is not installed, the model is not
+            downloaded, or the server can't be reached
+
+    Examples:
+        >>> llm_ensure_model_loaded('mistralai/mistral-7b-instruct-v0.3')  # already in memory
+        True
+        >>> llm_ensure_model_loaded('mistralai/mistral-7b-instruct-v0.3')  # was not loaded
+        False
+    """
+    caller = sys._getframe().f_code.co_name
+    if not model_key or str(model_key).strip() == '':
+        raise CyError('model_key must be a non-empty string', caller=caller)
+    lms = _import_lmstudio(caller)
+    try:
+        with lms.Client(api_host=host) as client:
+            handles = client.llm.list_loaded()
+            already_loaded = any(getattr(h, 'identifier', None) == model_key for h in handles)
+            if already_loaded:
+                return True
+            kwargs = {'ttl': ttl}
+            if config is not None:
+                kwargs['config'] = config
+            client.llm.load_new_instance(model_key, **kwargs)
+            return False
+    except CyError:
+        raise
+    except Exception as e:
+        raise CyError(f"Failed to ensure model '{model_key}' is loaded on host '{host}': {e}", caller=caller)

--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,9 @@ setuptools.setup(
         'backoff',
         'colour'
     ],
+    extras_require={
+        'llm': ['lmstudio>=1.0'],  # Optional: local LLM inference via LM Studio (see llm_inference module)
+    },
     classifiers=[
         'Intended Audience :: Science/Research',
         'Intended Audience :: Developers',

--- a/tests/test_llm_inference.py
+++ b/tests/test_llm_inference.py
@@ -1,0 +1,158 @@
+# -*- coding: utf-8 -*-
+
+""" Test functions in llm_inference.py.
+
+These are hermetic unit tests: the LM Studio SDK (``lmstudio``) and its server
+are mocked, so the tests require neither the optional ``lmstudio`` package nor a
+running LM Studio server.
+"""
+
+"""License:
+    Copyright 2020-2022 The Cytoscape Consortium
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+    documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+    and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all copies or substantial portions
+    of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+    WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS
+    OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+    OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+"""
+
+import sys
+import unittest
+from unittest import mock
+
+from py4cytoscape import llm_inference as llm
+from py4cytoscape.exceptions import CyError
+
+
+def _make_fake_lms(models=None, respond_return='response text', stream_fragments=None):
+    """Build a fake ``lmstudio`` module whose Client is a context manager.
+
+    Returns a tuple of (fake_lms, fake_model) so tests can assert on call args.
+    """
+    fake_model = mock.MagicMock(name='model')
+    fake_model.respond.return_value = respond_return
+
+    if stream_fragments is not None:
+        fake_model.respond_stream.return_value = iter(
+            [mock.MagicMock(content=frag) for frag in stream_fragments])
+
+    fake_client = mock.MagicMock(name='client')
+    # Support "with lms.Client(...) as client:"
+    fake_client.__enter__.return_value = fake_client
+    fake_client.__exit__.return_value = False
+    fake_client.llm.model.return_value = fake_model
+    fake_client.list_downloaded_models.return_value = models or []
+
+    fake_lms = mock.MagicMock(name='lmstudio')
+    fake_lms.Client.return_value = fake_client
+    return fake_lms, fake_model, fake_client
+
+
+class LLMInferenceTests(unittest.TestCase):
+
+    def test_public_api_exported(self):
+        # Verify the module-level functions are present
+        for name in ('llm_infer', 'llm_infer_stream', 'list_llm_models',
+                     'llm_server_reachable', 'DEFAULT_LLM_HOST'):
+            self.assertTrue(hasattr(llm, name), f'missing {name}')
+        self.assertEqual(llm.DEFAULT_LLM_HOST, 'localhost:1234')
+
+    def test_import_lmstudio_missing_raises_cyerror(self):
+        # Simulate the package being absent: a None entry in sys.modules makes
+        # "import lmstudio" raise ImportError.
+        original = sys.modules.get('lmstudio', mock.sentinel.absent)
+        sys.modules['lmstudio'] = None
+        try:
+            with self.assertRaises(CyError):
+                llm._import_lmstudio('test_caller')
+        finally:
+            if original is mock.sentinel.absent:
+                del sys.modules['lmstudio']
+            else:
+                sys.modules['lmstudio'] = original
+
+    def test_llm_infer_returns_text(self):
+        fake_lms, fake_model, _ = _make_fake_lms(respond_return='hello world')
+        with mock.patch.object(llm, '_import_lmstudio', return_value=fake_lms):
+            result = llm.llm_infer('Say hi', model_key='some/model')
+        self.assertEqual(result, 'hello world')
+        fake_model.respond.assert_called_once_with('Say hi')
+
+    def test_llm_infer_passes_config(self):
+        fake_lms, fake_model, _ = _make_fake_lms(respond_return='ok')
+        cfg = {'temperature': 0.2, 'maxTokens': 16}
+        with mock.patch.object(llm, '_import_lmstudio', return_value=fake_lms):
+            result = llm.llm_infer('prompt', model_key='m', config=cfg)
+        self.assertEqual(result, 'ok')
+        fake_model.respond.assert_called_once_with('prompt', config=cfg)
+
+    def test_llm_infer_uses_host(self):
+        fake_lms, _, _ = _make_fake_lms(respond_return='x')
+        with mock.patch.object(llm, '_import_lmstudio', return_value=fake_lms):
+            llm.llm_infer('p', host='example:9999')
+        fake_lms.Client.assert_called_once_with(api_host='example:9999')
+
+    def test_llm_infer_empty_prompt_raises(self):
+        fake_lms, _, _ = _make_fake_lms()
+        with mock.patch.object(llm, '_import_lmstudio', return_value=fake_lms):
+            with self.assertRaises(CyError):
+                llm.llm_infer('   ')
+            with self.assertRaises(CyError):
+                llm.llm_infer(None)
+
+    def test_llm_infer_wraps_sdk_error(self):
+        fake_lms, fake_model, _ = _make_fake_lms()
+        fake_model.respond.side_effect = RuntimeError('boom')
+        with mock.patch.object(llm, '_import_lmstudio', return_value=fake_lms):
+            with self.assertRaises(CyError):
+                llm.llm_infer('p', model_key='m')
+
+    def test_list_llm_models(self):
+        m1 = mock.MagicMock(model_key='org/model-a')
+        m2 = mock.MagicMock(model_key='org/model-b')
+        fake_lms, _, _ = _make_fake_lms(models=[m1, m2])
+        with mock.patch.object(llm, '_import_lmstudio', return_value=fake_lms):
+            keys = llm.list_llm_models()
+        self.assertEqual(keys, ['org/model-a', 'org/model-b'])
+
+    def test_list_llm_models_connection_error_raises(self):
+        fake_lms, _, fake_client = _make_fake_lms()
+        fake_client.list_downloaded_models.side_effect = ConnectionError('down')
+        with mock.patch.object(llm, '_import_lmstudio', return_value=fake_lms):
+            with self.assertRaises(CyError):
+                llm.list_llm_models()
+
+    def test_llm_server_reachable_true(self):
+        fake_lms, _, _ = _make_fake_lms(models=[])
+        with mock.patch.object(llm, '_import_lmstudio', return_value=fake_lms):
+            self.assertTrue(llm.llm_server_reachable())
+
+    def test_llm_server_reachable_false(self):
+        fake_lms, _, fake_client = _make_fake_lms()
+        fake_client.list_downloaded_models.side_effect = ConnectionError('down')
+        with mock.patch.object(llm, '_import_lmstudio', return_value=fake_lms):
+            self.assertFalse(llm.llm_server_reachable())
+
+    def test_llm_infer_stream_yields_fragments(self):
+        fake_lms, _, _ = _make_fake_lms(stream_fragments=['Hello', ', ', 'world'])
+        with mock.patch.object(llm, '_import_lmstudio', return_value=fake_lms):
+            out = ''.join(llm.llm_infer_stream('prompt', model_key='m'))
+        self.assertEqual(out, 'Hello, world')
+
+    def test_llm_infer_stream_empty_prompt_raises(self):
+        fake_lms, _, _ = _make_fake_lms(stream_fragments=[])
+        with mock.patch.object(llm, '_import_lmstudio', return_value=fake_lms):
+            with self.assertRaises(CyError):
+                llm.llm_infer_stream('')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_llm_inference.py
+++ b/tests/test_llm_inference.py
@@ -32,10 +32,23 @@ from py4cytoscape import llm_inference as llm
 from py4cytoscape.exceptions import CyError
 
 
-def _make_fake_lms(models=None, respond_return='response text', stream_fragments=None):
+def _make_handle(identifier):
+    """Return a minimal fake model handle with an ``identifier`` attribute."""
+    h = mock.MagicMock(name=f'handle:{identifier}')
+    h.identifier = identifier
+    return h
+
+
+def _make_fake_lms(models=None, respond_return='response text', stream_fragments=None,
+                   loaded_handles=None):
     """Build a fake ``lmstudio`` module whose Client is a context manager.
 
-    Returns a tuple of (fake_lms, fake_model) so tests can assert on call args.
+    Returns a tuple of (fake_lms, fake_model, fake_client) so tests can assert
+    on call args.
+
+    Args:
+        loaded_handles: list of fake model handles returned by ``client.llm.list_loaded``.
+            Defaults to an empty list.
     """
     fake_model = mock.MagicMock(name='model')
     fake_model.respond.return_value = respond_return
@@ -50,6 +63,9 @@ def _make_fake_lms(models=None, respond_return='response text', stream_fragments
     fake_client.__exit__.return_value = False
     fake_client.llm.model.return_value = fake_model
     fake_client.list_downloaded_models.return_value = models or []
+    fake_client.llm.list_loaded.return_value = loaded_handles if loaded_handles is not None else []
+    # load_new_instance returns a handle with identifier = first arg by default
+    fake_client.llm.load_new_instance.side_effect = lambda key, **_: _make_handle(key)
 
     fake_lms = mock.MagicMock(name='lmstudio')
     fake_lms.Client.return_value = fake_client
@@ -59,9 +75,11 @@ def _make_fake_lms(models=None, respond_return='response text', stream_fragments
 class LLMInferenceTests(unittest.TestCase):
 
     def test_public_api_exported(self):
-        # Verify the module-level functions are present
+        # Verify all module-level functions are present
         for name in ('llm_infer', 'llm_infer_stream', 'list_llm_models',
-                     'llm_server_reachable', 'DEFAULT_LLM_HOST'):
+                     'llm_server_reachable', 'llm_load_model', 'llm_unload_model',
+                     'llm_ensure_model_loaded', 'llm_list_loaded_models',
+                     'DEFAULT_LLM_HOST'):
             self.assertTrue(hasattr(llm, name), f'missing {name}')
         self.assertEqual(llm.DEFAULT_LLM_HOST, 'localhost:1234')
 
@@ -152,6 +170,156 @@ class LLMInferenceTests(unittest.TestCase):
         with mock.patch.object(llm, '_import_lmstudio', return_value=fake_lms):
             with self.assertRaises(CyError):
                 llm.llm_infer_stream('')
+
+
+class LLMModelManagementTests(unittest.TestCase):
+    """Tests for llm_list_loaded_models, llm_load_model,
+    llm_unload_model, and llm_ensure_model_loaded."""
+
+    # ------------------------------------------------------------------
+    # llm_list_loaded_models
+    # ------------------------------------------------------------------
+
+    def test_list_loaded_models_empty(self):
+        fake_lms, _, _ = _make_fake_lms(loaded_handles=[])
+        with mock.patch.object(llm, '_import_lmstudio', return_value=fake_lms):
+            self.assertEqual(llm.llm_list_loaded_models(), [])
+
+    def test_list_loaded_models_returns_identifiers(self):
+        handles = [_make_handle('org/model-a'), _make_handle('org/model-b')]
+        fake_lms, _, _ = _make_fake_lms(loaded_handles=handles)
+        with mock.patch.object(llm, '_import_lmstudio', return_value=fake_lms):
+            result = llm.llm_list_loaded_models()
+        self.assertEqual(result, ['org/model-a', 'org/model-b'])
+
+    def test_list_loaded_models_server_error_raises(self):
+        fake_lms, _, fake_client = _make_fake_lms()
+        fake_client.llm.list_loaded.side_effect = ConnectionError('down')
+        with mock.patch.object(llm, '_import_lmstudio', return_value=fake_lms):
+            with self.assertRaises(CyError):
+                llm.llm_list_loaded_models()
+
+    # ------------------------------------------------------------------
+    # llm_load_model
+    # ------------------------------------------------------------------
+
+    def test_load_model_calls_load_new_instance(self):
+        fake_lms, _, fake_client = _make_fake_lms(loaded_handles=[])
+        with mock.patch.object(llm, '_import_lmstudio', return_value=fake_lms):
+            result = llm.llm_load_model('org/model-x')
+        fake_client.llm.load_new_instance.assert_called_once_with('org/model-x', ttl=3600)
+        self.assertEqual(result, 'org/model-x')
+
+    def test_load_model_idempotent_when_already_loaded(self):
+        handles = [_make_handle('org/model-x')]
+        fake_lms, _, fake_client = _make_fake_lms(loaded_handles=handles)
+        with mock.patch.object(llm, '_import_lmstudio', return_value=fake_lms):
+            result = llm.llm_load_model('org/model-x')
+        fake_client.llm.load_new_instance.assert_not_called()
+        self.assertEqual(result, 'org/model-x')
+
+    def test_load_model_passes_ttl_and_config(self):
+        fake_lms, _, fake_client = _make_fake_lms(loaded_handles=[])
+        cfg = {'contextLength': 4096}
+        with mock.patch.object(llm, '_import_lmstudio', return_value=fake_lms):
+            llm.llm_load_model('org/m', ttl=None, config=cfg)
+        fake_client.llm.load_new_instance.assert_called_once_with(
+            'org/m', ttl=None, config=cfg)
+
+    def test_load_model_passes_custom_identifier(self):
+        fake_lms, _, fake_client = _make_fake_lms(loaded_handles=[])
+        with mock.patch.object(llm, '_import_lmstudio', return_value=fake_lms):
+            llm.llm_load_model('org/m', identifier='my-instance')
+        fake_client.llm.load_new_instance.assert_called_once_with(
+            'org/m', ttl=3600, instance_identifier='my-instance')
+
+    def test_load_model_empty_key_raises(self):
+        fake_lms, _, _ = _make_fake_lms()
+        with mock.patch.object(llm, '_import_lmstudio', return_value=fake_lms):
+            with self.assertRaises(CyError):
+                llm.llm_load_model('')
+            with self.assertRaises(CyError):
+                llm.llm_load_model(None)
+
+    def test_load_model_sdk_error_raises(self):
+        fake_lms, _, fake_client = _make_fake_lms(loaded_handles=[])
+        fake_client.llm.load_new_instance.side_effect = RuntimeError('no disk')
+        with mock.patch.object(llm, '_import_lmstudio', return_value=fake_lms):
+            with self.assertRaises(CyError):
+                llm.llm_load_model('org/m')
+
+    # ------------------------------------------------------------------
+    # llm_unload_model
+    # ------------------------------------------------------------------
+
+    def test_unload_model_loaded(self):
+        handles = [_make_handle('org/model-x')]
+        fake_lms, _, fake_client = _make_fake_lms(loaded_handles=handles)
+        with mock.patch.object(llm, '_import_lmstudio', return_value=fake_lms):
+            result = llm.llm_unload_model('org/model-x')
+        self.assertTrue(result)
+        fake_client.llm.unload.assert_called_once_with('org/model-x')
+
+    def test_unload_model_not_loaded_returns_false(self):
+        fake_lms, _, fake_client = _make_fake_lms(loaded_handles=[])
+        with mock.patch.object(llm, '_import_lmstudio', return_value=fake_lms):
+            result = llm.llm_unload_model('org/model-x')
+        self.assertFalse(result)
+        fake_client.llm.unload.assert_not_called()
+
+    def test_unload_model_empty_key_raises(self):
+        fake_lms, _, _ = _make_fake_lms()
+        with mock.patch.object(llm, '_import_lmstudio', return_value=fake_lms):
+            with self.assertRaises(CyError):
+                llm.llm_unload_model('')
+
+    def test_unload_model_sdk_error_raises(self):
+        handles = [_make_handle('org/m')]
+        fake_lms, _, fake_client = _make_fake_lms(loaded_handles=handles)
+        fake_client.llm.unload.side_effect = RuntimeError('fail')
+        with mock.patch.object(llm, '_import_lmstudio', return_value=fake_lms):
+            with self.assertRaises(CyError):
+                llm.llm_unload_model('org/m')
+
+    # ------------------------------------------------------------------
+    # llm_ensure_model_loaded
+    # ------------------------------------------------------------------
+
+    def test_ensure_model_loaded_already_loaded_returns_true(self):
+        handles = [_make_handle('org/model-x')]
+        fake_lms, _, fake_client = _make_fake_lms(loaded_handles=handles)
+        with mock.patch.object(llm, '_import_lmstudio', return_value=fake_lms):
+            result = llm.llm_ensure_model_loaded('org/model-x')
+        self.assertTrue(result)
+        fake_client.llm.load_new_instance.assert_not_called()
+
+    def test_ensure_model_loaded_not_loaded_loads_and_returns_false(self):
+        fake_lms, _, fake_client = _make_fake_lms(loaded_handles=[])
+        with mock.patch.object(llm, '_import_lmstudio', return_value=fake_lms):
+            result = llm.llm_ensure_model_loaded('org/model-x')
+        self.assertFalse(result)
+        fake_client.llm.load_new_instance.assert_called_once_with('org/model-x', ttl=3600)
+
+    def test_ensure_model_loaded_passes_config(self):
+        fake_lms, _, fake_client = _make_fake_lms(loaded_handles=[])
+        cfg = {'contextLength': 2048}
+        with mock.patch.object(llm, '_import_lmstudio', return_value=fake_lms):
+            llm.llm_ensure_model_loaded('org/m', ttl=600, config=cfg)
+        fake_client.llm.load_new_instance.assert_called_once_with(
+            'org/m', ttl=600, config=cfg)
+
+    def test_ensure_model_loaded_empty_key_raises(self):
+        fake_lms, _, _ = _make_fake_lms()
+        with mock.patch.object(llm, '_import_lmstudio', return_value=fake_lms):
+            with self.assertRaises(CyError):
+                llm.llm_ensure_model_loaded('')
+
+    def test_ensure_model_loaded_sdk_error_raises(self):
+        fake_lms, _, fake_client = _make_fake_lms(loaded_handles=[])
+        fake_client.llm.load_new_instance.side_effect = RuntimeError('oom')
+        with mock.patch.object(llm, '_import_lmstudio', return_value=fake_lms):
+            with self.assertRaises(CyError):
+                llm.llm_ensure_model_loaded('org/m')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
Adds a new optional utility module, \`py4cytoscape/llm_inference.py\`, that wraps the [LM Studio Python SDK](https://pypi.org/project/lmstudio/) to run **local** LLM inference against a running LM Studio server. This lets py4cytoscape workflows use a local model (e.g., to summarize a network or draft annotations) without any cloud dependency.

## What's added
- **Module** \`py4cytoscape/llm_inference.py\` (follows repo conventions: UTF-8 header + license block, \`@cy_log\`, \`CyError\`, Google-style docstrings):

  _Inference_
  - \`llm_infer(prompt, model_key, host, config)\` — single-shot completion → \`str\`
  - \`llm_infer_stream(...)\` — streaming generator of text fragments
  - \`list_llm_models(host)\` — list downloaded model keys
  - \`llm_server_reachable(host)\` — connectivity check
  - \`DEFAULT_LLM_HOST = 'localhost:1234'\`

  _Model management_
  - \`llm_list_loaded_models(host)\` — list identifiers of models currently in memory
  - \`llm_load_model(model_key, identifier, ttl, config, host)\` — load a model (idempotent: skips if already loaded)
  - \`llm_unload_model(model_key, host)\` — unload a model; no-op (returns \`False\`) if not loaded
  - \`llm_ensure_model_loaded(model_key, ttl, config, host)\` — load only if not in memory; returns \`True\` (was already loaded) / \`False\` (had to load)

- **Optional dependency**: \`lmstudio\` is imported lazily; if absent, functions raise a \`CyError\` with install guidance. Declared in \`setup.py\` as \`extras_require={'llm': ['lmstudio>=1.0']}\` — no impact on the base install.
- **Package export**: \`from .llm_inference import *\` in \`__init__.py\`.
- **Tests**: \`tests/test_llm_inference.py\` — **31 hermetic unit tests** using \`unittest.mock\` (no live server or \`lmstudio\` package required across two test classes):
  - \`LLMInferenceTests\` (13): return values, config/host pass-through, input validation, error wrapping, model listing, reachability, streaming, missing-package path.
  - \`LLMModelManagementTests\` (18): list/load/unload/ensure semantics, idempotency, no-op behaviour, empty-key validation, SDK-error wrapping.

## Testing
\`python -m unittest tests.test_llm_inference -v\` → **Ran 31 tests … OK** (0.027s). The module was also validated end-to-end against a live LM Studio server (Mistral 7B) for both inference and model lifecycle (load → unload → reload → ensure).

## Notes
This introduces a new optional integration surface with no required dependencies. Feedback welcome on naming and whether this belongs in the core package vs. an example/contrib location.

Co-Authored-By: Oz <oz-agent@warp.dev>